### PR TITLE
fix: getCurrentUser에서 user 못 받아오던 오류 해결

### DIFF
--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/controller/AuthController.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/controller/AuthController.java
@@ -134,4 +134,13 @@ public class AuthController {
         return null;
     }
 
+    //////user service test용. 사용 후 삭제
+    @GetMapping("/user/me")
+    public ResponseEntity<?> getMyInfo() {
+        User user = userService.getCurrentUser();
+
+        return ResponseEntity.ok()
+                .body("🙋‍♀️ 현재 유저: " + user.getName() + " (id: " + user.getUserId() + ")");
+    }
+
 }

--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/domain/CustomUserDetails.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/domain/CustomUserDetails.java
@@ -11,10 +11,12 @@ import java.util.Collections;
 public class CustomUserDetails implements UserDetails {
     private final Long id;
     private final String email;
+    private final String name;
 
-    public CustomUserDetails(Long id, String email) {
+    public CustomUserDetails(Long id, String email, String name) {
         this.id = id;
         this.email = email;
+        this.name = name;
     }
 
     @Override

--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/jwt/JwtAuthenticationFilter.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,9 @@
 package com.efub.agodaclone.user.jwt;
 
 import com.efub.agodaclone.global.exception.ClientExceptionCode;
+import com.efub.agodaclone.user.domain.CustomUserDetails;
+import com.efub.agodaclone.user.domain.User;
+import com.efub.agodaclone.user.repository.UserRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -21,6 +24,7 @@ import java.util.List;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -33,8 +37,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             try {
                 Long userId = jwtProvider.validateAndGetUserId(token);
 
+                User user = userRepository.findById(userId).orElseThrow();
+                CustomUserDetails userDetails = new CustomUserDetails(user.getUserId(), user.getEmail(), user.getName());
+
                 UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(userId, null,
+                        new UsernamePasswordAuthenticationToken(userDetails, null,
                                 List.of(new SimpleGrantedAuthority("ROLE_USER")));
 
                 request.setAttribute("userId", userId);

--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/service/KakaoService.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/service/KakaoService.java
@@ -43,6 +43,7 @@ public class KakaoService {
         return response.getBody().getAccessToken();
     }
 
+    //카카오에서 user 정보 받아옴
     public KakaoUserInfo getUserInfo(String accessToken) {
         String userInfoUrl = "https://kapi.kakao.com/v2/user/me";
 

--- a/agoda-clone/src/main/resources/static/kakao-login.html
+++ b/agoda-clone/src/main/resources/static/kakao-login.html
@@ -15,7 +15,7 @@
 
     document.getElementById('kakao-login-btn').addEventListener('click', function () {
         Kakao.Auth.authorize({
-            redirectUri: 'http://localhost:8080/kakao/callback'
+            redirectUri: 'http://localhost:8080/oauth/login'
         });
     });
 </script>


### PR DESCRIPTION
## 📌 PR 제목
- 예: "[Feat] 로그인 API 구현"
- 예: "[Update] 회원가입 시 중복 체크 로직 개선"
- 예: "[Fix] 카카오 로그인 에러 수정"



## ✅ 요약
해당 PR에서 어떤 작업을 했는지 요약해주세요.
(아래 부분은 지우고 작성)
- 예) 로그인 API 구현
- 예) 이메일 중복 검사 추가



## 🔎 테스트 내용
어떤 테스트를 수행했는지 명시해주세요.  

- [ ] Postman 테스트
- [ ] 단위 테스트 수행

## 🧠 구현 과정에서의 고민
구현하면서 어떤 점을 고민했는지 공유해주세요.

(아래 부분은 지우고 작성)
- 어떤 구조로 작성할지 고민함 (ex: 인증 로직 위치)
- JPA 연관관계 설정 중 순환참조 이슈 발생
- DTO 설계 시 필드 분리 기준에 대해 고민


## ⚠️ 어려웠던 점과 해결 과정
막혔던 부분과 어떻게 해결했는지 작성해주세요.
(아래 부분은 지우고 작성)
- 카카오 로그인 시 리다이렉트 URI 불일치 → application.yml에 도메인 설정 누락이 원인
- JWT 토큰 검증 시 401 발생 → 필터 순서 문제였음
  

## ⚠️ 참고 사항 및 주의할 점
(아래 부분은 지우고 작성)
- 예) 토큰 유효기간 관련 설정이 아직 미완입니다.
- 예) 비밀번호 암호화 방식은 추후 논의 필요합니다.

## 🗯️ 느낀 점 / 다음에 개선하고 싶은 점 (선택)
- 다음에는 OAuth 로그인과 일반 로그인을 공통 인터페이스로 리팩토링하면 좋을 것 같다

## 🧾 관련 이슈
이 PR이 연결된 이슈가 있다면 작성해주세요.

- closes #이슈번호
